### PR TITLE
Download mods from redirect links

### DIFF
--- a/JiayiLauncher/CREDITS.txt
+++ b/JiayiLauncher/CREDITS.txt
@@ -5,7 +5,7 @@ Testers:
 AvoidFrankie • fizz • n3twoik • Sir Gary • SlySlacker • CheemzZ • f*ck! • hmmm_ • ItzPhoenix • Rainny. • TTF_fog • bolo
 
 Contributors (up to this release):
-GacekKosmatek • CuteNyami • Flash_
+GacekKosmatek • CuteNyami • Flash_ • Plextora
 
 VIPs (from the Discord server):
 bolo • NoSkillPureAndy • pod • rice • VastraKai • DeathlyBower959 • megahendrik (happened again) • hgrvbrrds • JayRSky

--- a/JiayiLauncher/CREDITS.txt
+++ b/JiayiLauncher/CREDITS.txt
@@ -14,7 +14,7 @@ Press:
 GroundedChild • SpinierYard212 • YaGoat
 
 And finally, greets to:
-mrarm and dktapps for some version manager code • White • Bionic • Floppy • Plextora • riester (meowmeowcat12) • brook(e) • Dr.FarFar • the StarZ team for being my #1 haters • DeadSafari • Distant • GamerPP • DidntPot • kelvinn • xqwo • Plu4qlEve • arson/penguin/qieh • Haze. • jqms • 12brendon34 • ByArth • Kl0dz • notshige • Exallotriote • Hammond • the people over at CSI • j* • Aether • Frostify • my mom lol
+mrarm and dktapps for some version manager code • White • Bionic • Floppy • riester (meowmeowcat12) • brook(e) • Dr.FarFar • the StarZ team for being my #1 haters • DeadSafari • Distant • GamerPP • DidntPot • kelvinn • xqwo • Plu4qlEve • arson/penguin/qieh • Haze. • jqms • 12brendon34 • ByArth • Kl0dz • notshige • Exallotriote • Hammond • the people over at CSI • j* • Aether • Frostify • my mom lol
 
 Jiayi Launcher is released under the GNU General Public License, version 3.0. You can find the source code on GitHub.
 If you bought this program, you were scammed!

--- a/JiayiLauncher/Features/Launch/Downloader.cs
+++ b/JiayiLauncher/Features/Launch/Downloader.cs
@@ -29,7 +29,7 @@ public static class Downloader
 
         if (response.Content.Headers.ContentDisposition is not { FileName: not null })
         {
-            Log.Write(nameof(Downloader), "Server did not provide a file name", Log.LogLevel.Error);
+            Log.Write(nameof(Downloader), "Server did not provide a file name", Log.LogLevel.Warning);
             isFileName = false;
         }
 

--- a/JiayiLauncher/Features/Launch/Downloader.cs
+++ b/JiayiLauncher/Features/Launch/Downloader.cs
@@ -35,8 +35,8 @@ public static class Downloader
         }
 
         var path = Path.Combine(ModCollection.Current!.BasePath, hasFileName ?
-							   	response.Content.Headers.ContentDisposition.FileName.Replace("\"", ""))
-								: fileName.Replace("\"", ""))
+							   	response.Content.Headers.ContentDisposition.FileName.Replace("\"", "")
+								: fileName.Replace("\"", ""));
 
         // check if the file already exists, and if so, compare the hashes
         if (File.Exists(path))

--- a/JiayiLauncher/Modals/NewMod.razor
+++ b/JiayiLauncher/Modals/NewMod.razor
@@ -104,6 +104,66 @@
         }
     }
 
+    public static string GetFinalRedirect(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return url;
+
+        int maxRedirCount = 8;  // prevent infinite loops
+        string newUrl = url;
+        do
+        {
+            HttpWebRequest req = null;
+            HttpWebResponse resp = null;
+            try
+            {
+                req = (HttpWebRequest)HttpWebRequest.Create(url);
+                req.Method = "HEAD";
+                req.AllowAutoRedirect = false;
+                resp = (HttpWebResponse)req.GetResponse();
+                switch (resp.StatusCode)
+                {
+                    case HttpStatusCode.OK:
+                        return newUrl;
+                    case HttpStatusCode.Redirect:
+                    case HttpStatusCode.MovedPermanently:
+                    case HttpStatusCode.RedirectKeepVerb:
+                    case HttpStatusCode.RedirectMethod:
+                        newUrl = resp.Headers["Location"];
+                        if (newUrl == null)
+                            return url;
+
+                        if (newUrl.IndexOf("://", System.StringComparison.Ordinal) == -1)
+                        {
+                            // Doesn't have a URL Schema, meaning it's a relative or absolute URL
+                            Uri u = new Uri(new Uri(url), newUrl);
+                            newUrl = u.ToString();
+                        }
+                        break;
+                    default:
+                        return newUrl;
+                }
+                url = newUrl;
+            }
+            catch (WebException)
+            {
+                // Return the last known good URL
+                return newUrl;
+            }
+            catch (Exception ex)
+            {
+                return null;
+            }
+            finally
+            {
+                if (resp != null)
+                    resp.Close();
+            }
+        } while (maxRedirCount-- > 0);
+
+        return newUrl;
+    } // totally not taken from stackoverflow (https://stackoverflow.com/a/28424940)
+
     private async Task LinkSubmitted()
     {
         // wait for the text box to update
@@ -114,6 +174,8 @@
 
         if (!url.StartsWith("http"))
             url = "https://" + url;
+        string redirect = GetFinalRedirect(url);
+        url = redirect;
 
         Uri uri;
 


### PR DESCRIPTION
Example: if you put the web link "horion.download/dll", it will use the link it redirects to (https://horion.download/bin/Horion.dll) instead of just saying "Invalid link"

Also, downloading a DLL from the web without a filename does not fail the download anymore, because that's cringe